### PR TITLE
Fix customErrors + blurPredicate

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -31,6 +31,26 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "theblushingcrow",
+      "name": "Inbal Sinai",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/638818?v=4",
+      "profile": "https://github.com/theblushingcrow",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "dmorosinotto",
+      "name": "Daniele Morosinotto",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/3982050?v=4",
+      "profile": "https://twitter.com/dmorosinotto",
+      "contributions": [
+        "code",
+        "doc",
+        "example"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ The custom `anchor` can also be added as a directive, in which case it'll act as
 </div>
 ```
 
-- `customErrors` - Additional errors to use for the form field, that aren't specified in the config:
+- `controlErrors` - Additional errors to use for the form field, that aren't specified in the config:
 
 ```html
-<input class="form-control" formControlName="city" placeholder="City" [customErrors]="serverErrors" />
+<input class="form-control" formControlName="country" placeholder="Country" [controlErrors]="extraErrors" />
 ```
 
 ## CSS Styling
@@ -169,16 +169,19 @@ The library adds a `form-submitted` to the submitted form. You can use it to sty
 ```ts
 {
   blurPredicate(element) {
-    return element.tagName === 'INPUT';
+    return element.tagName === 'INPUT' || element.tagName === 'SELECT';
   }
 }
 ```
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 
 - # `controlErrorsOnBlur` - To modify the error display behavior and show the errors on submission alone, set the following input:
 - `controlErrorsOnBlur` - To modify the error display behavior and show the errors on submission alone, set the following input:
-  > > > > > > > master
+  > > > > > > > # master
+- `controlErrorsOnBlur` - To modify the error display behavior and show the errors on submission alone, set the following input:
+  > > > > > > > fix: 🐛 customErrors + blurPredicate
 
 ```html
 <input [controlErrorsOnBlur]="false" formControlName="name" />

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Sit back, relax, and let the Error Tailor do all the work!
 
 Run `ng add @ngneat/error-tailor`. This command updates the `AppModule`, and adds the `ErrorTailorModule` dependency:
 
+<!-- prettier-ignore-start -->
 ```ts
 @NgModule({
   declarations: [AppComponent],
@@ -32,8 +33,9 @@ Run `ng add @ngneat/error-tailor`. This command updates the `AppModule`, and add
     ErrorTailorModule.forRoot({
       errors: {
         useValue: {
-          required: error => `This field is required`,
-          minlength: ({ requiredLength, actualLength }) => `Expect ${requiredLength} but got ${actualLength}`,
+          required: 'This field is required',
+          minlength: ({ requiredLength, actualLength }) => 
+                      `Expect ${requiredLength} but got ${actualLength}`,
           invalidAddress: error => `Address isn't valid`
         }
       }
@@ -43,8 +45,9 @@ Run `ng add @ngneat/error-tailor`. This command updates the `AppModule`, and add
 })
 export class AppModule {}
 ```
+<!-- prettier-ignore-end -->
 
-The `errors` config property takes a partial `Provider`, that should provide an object containing the form errors.
+The `errors` config property takes a partial `Provider`, that should provide a `HashMap< string | (err:any) => string >` that is an object with keys corresponding to the errors name that you want to handle, and values that can be a simple string, or function that return a string used as error message to be shown.
 Now the only thing you need to add is the `errorTailor` directive to your form:
 
 ```html
@@ -232,13 +235,13 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   <tr>
     <td align="center"><a href="https://www.netbasal.com"><img src="https://avatars1.githubusercontent.com/u/6745730?v=4" width="100px;" alt=""/><br /><sub><b>Netanel Basal</b></sub></a><br /><a href="https://github.com/@ngneat/error-tailor/commits?author=NetanelBasal" title="Code">💻</a> <a href="https://github.com/@ngneat/error-tailor/commits?author=NetanelBasal" title="Documentation">📖</a> <a href="#ideas-NetanelBasal" title="Ideas, Planning, & Feedback">🤔</a> <a href="#infra-NetanelBasal" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a></td>
     <td align="center"><a href="https://github.com/tonivj5"><img src="https://avatars2.githubusercontent.com/u/7110786?v=4" width="100px;" alt=""/><br /><sub><b>Toni Villena</b></sub></a><br /><a href="https://github.com/@ngneat/error-tailor/commits?author=tonivj5" title="Code">💻</a> <a href="https://github.com/@ngneat/error-tailor/commits?author=tonivj5" title="Tests">⚠️</a></td>
-    <td align="center"><a href="https://github.com/theblushingcrow"><img src="https://avatars3.githubusercontent.com/u/638818?v=4" width="100px;" alt=""/><br /><sub><b>Inbal Sinai</b></sub></a><br /><a href="https://github.com/@ngneat/error-tailor/commits?author=theblushingcrow" title="Documentation">📖</a> </td>
+    <td align="center"><a href="https://github.com/theblushingcrow"><img src="https://avatars3.githubusercontent.com/u/638818?v=4" width="100px;" alt=""/><br /><sub><b>Inbal Sinai</b></sub></a><br /><a href="https://github.com/@ngneat/error-tailor/commits?author=theblushingcrow" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://twitter.com/dmorosinotto"><img src="https://avatars2.githubusercontent.com/u/3982050?v=4" width="100px;" alt=""/><br /><sub><b>Daniele Morosinotto</b></sub></a><br /><a href="https://github.com/@ngneat/error-tailor/commits?author=dmorosinotto" title="Code">💻</a> <a href="https://github.com/@ngneat/error-tailor/commits?author=dmorosinotto" title="Documentation">📖</a> <a href="#example-dmorosinotto" title="Examples">💡</a></td>
   </tr>
 </table>
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
-
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/README.md
+++ b/README.md
@@ -31,12 +31,11 @@ Run `ng add @ngneat/error-tailor`. This command updates the `AppModule`, and add
     ReactiveFormsModule,
     ErrorTailorModule.forRoot({
       errors: {
-        useValue() {
+        useValue: {
           required: error => `This field is required`,
-          minlength: ({ requiredLength, actualLength }) => 
-                       `Expect ${requiredLength} but got ${actualLength}`,
+          minlength: ({ requiredLength, actualLength }) => `Expect ${requiredLength} but got ${actualLength}`,
           invalidAddress: error => `Address isn't valid`
-        },
+      }
       }
     })
   ],
@@ -102,18 +101,21 @@ export class AppComponent {
 The directive will show all errors for a form field automatically in two instances - on the field element blur and on form submit.
 
 ## Inputs
+
 - `controlErrorsClass` - A custom class that'll be added to the control error component, a component that is added after the form field when an error needs to be displayed:
+
 ```html
-<input class="form-control" formControlName="city" placeholder="City" controlErrorsClass="my-class"/>
+<input class="form-control" formControlName="city" placeholder="City" controlErrorsClass="my-class" />
 ```
 
 - `controlErrorsTpl` - A custom error template to be used instead of the control error component's default view:
+
 ```html
 <form errorTailor>
   <ng-template let-error let-text="text" #tpl> {{ error | json }} {{ text }} </ng-template>
 
   <div class="form-group">
-    <input class="form-control" ngModel="name" required name="name" [controlErrorsTpl]="tpl" />
+    <input class="form-control" ngModel required name="name" [controlErrorsTpl]="tpl" />
   </div>
 
   <button class="btn btn-success">Submit</button>
@@ -121,6 +123,7 @@ The directive will show all errors for a form field automatically in two instanc
 ```
 
 - `controlErrorAnchor` - A custom `anchor` element for the control error component. The default anchor is the form field element:
+
 ```html
 <div class="form-check form-group">
   <input type="checkbox" formControlName="terms" id="check" [controlErrorAnchor]="anchor" />
@@ -148,6 +151,7 @@ The custom `anchor` can also be added as a directive, in which case it'll act as
 ```
 
 ## CSS Styling
+
 The library adds a `form-submitted` to the submitted form. You can use it to style your inputs:
 
 ```css
@@ -166,7 +170,9 @@ The library adds a `form-submitted` to the submitted form. You can use it to sty
   }
 }
 ```
+
 - `controlErrorsOnBlur` - To modify the error display behavior and show the errors on submission alone, set the following input: 
+
 ```html
 <input [controlErrorsOnBlur]="false" formControlName="name" />
 ```
@@ -174,6 +180,7 @@ The library adds a `form-submitted` to the submitted form. You can use it to sty
 ## Recipies
 
 ### I18n Example
+
 Here's how to support i18n:
 
 ```ts
@@ -186,7 +193,7 @@ import { TranslocoService } from '@ngneat/transloco';
       errors: {
         useFactory(service: TranslocoService) {
           return {
-            required: error => service.translate('errors.required'),
+            required: error => service.translate('errors.required')
           };
         },
         deps: [TranslocoService]
@@ -198,8 +205,8 @@ import { TranslocoService } from '@ngneat/transloco';
 export class AppModule {}
 ```
 
-
 ### Control Error Style
+
 Here's a default style you can use for the error component:
 
 ```css
@@ -228,6 +235,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/README.md
+++ b/README.md
@@ -174,14 +174,7 @@ The library adds a `form-submitted` to the submitted form. You can use it to sty
 }
 ```
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-
-- # `controlErrorsOnBlur` - To modify the error display behavior and show the errors on submission alone, set the following input:
 - `controlErrorsOnBlur` - To modify the error display behavior and show the errors on submission alone, set the following input:
-  > > > > > > > # master
-- `controlErrorsOnBlur` - To modify the error display behavior and show the errors on submission alone, set the following input:
-  > > > > > > > fix: 🐛 customErrors + blurPredicate
 
 ```html
 <input [controlErrorsOnBlur]="false" formControlName="name" />

--- a/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
@@ -96,6 +96,7 @@ export class ControlErrorsDirective implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.destroy.next();
     if (this.ref) this.ref.destroy();
+    this.ref = null;
   }
 
   private valueChanges() {

--- a/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
@@ -95,18 +95,19 @@ export class ControlErrorsDirective implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.destroy.next();
+    if (this.ref) this.ref.destroy();
   }
 
   private valueChanges() {
     const controlErrors = this.control.errors;
     if (controlErrors) {
       const [firstKey] = Object.keys(controlErrors);
-      const getError = this.globalErrors[firstKey];
-      if (typeof getError !== 'function') {
+      const getError = this.customErrors[firstKey] || this.globalErrors[firstKey];
+      if (!getError) {
         return;
       }
 
-      const text = this.customErrors[firstKey] || getError(controlErrors[firstKey]);
+      const text = typeof getError === 'function' ? getError(controlErrors[firstKey]) : getError;
       this.setError(text, controlErrors);
     } else if (this.ref) {
       this.setError(null);
@@ -128,7 +129,7 @@ export class ControlErrorsDirective implements OnInit, OnDestroy {
     return {
       ...{
         blurPredicate(element) {
-          return element.tagName === 'INPUT';
+          return element.tagName === 'INPUT' || element.tagName === 'SELECT';
         }
       },
       ...this.config

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -14,7 +14,7 @@
 
   <section formGroupName="address">
     <div class="form-group">
-      <input class="form-control" formControlName="city" placeholder="City" />
+      <input class="form-control" formControlName="city" placeholder="City" controlErrorsClass="my-class" />
     </div>
 
     <div class="form-group">
@@ -39,7 +39,7 @@
 
 <form #f="ngForm" errorTailor>
   <div class="form-group">
-    <input class="form-control" ngModel="model" required name="model" />
+    <input class="form-control" [(ngModel)]="model" required name="model" />
   </div>
   <button class="btn btn-success">Submit</button>
   {{ f.value | json }}
@@ -47,11 +47,11 @@
 
 <h1>Custom Template</h1>
 
-<form #f="ngForm" errorTailor>
+<form errorTailor>
   <ng-template let-error let-text="text" #tpl> {{ error | json }} {{ text }} </ng-template>
 
   <div class="form-group">
-    <input class="form-control" ngModel="name" required name="name" [controlErrorsTpl]="tpl" />
+    <input class="form-control" ngModel required name="name" [controlErrorsOnBlur]="false" [controlErrorsTpl]="tpl" />
   </div>
   <button class="btn btn-success">Submit</button>
 </form>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -18,12 +18,13 @@
     </div>
 
     <div class="form-group">
-      <input class="form-control" formControlName="country" placeholder="Country" />
+      <input class="form-control" formControlName="country" placeholder="Country" [controlErrors]="extraErrors" />
     </div>
   </section>
 
   <div class="form-group">
     <select formControlName="animal" class="form-control">
+      <option [ngValue]="null">- -</option>
       <option *ngFor="let option of options; index as index" [ngValue]="option">
         {{ option.label }}
       </option>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,4 @@
+::ng-deep .my-class {
+  border: 1px solid red;
+  border-radius: 3px;
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -15,6 +15,11 @@ export class AppComponent {
     id: i + 1
   }));
 
+  extraErrors = {
+    minlength: ({ requiredLength }) => `Use country abbreviation! (min ${requiredLength} chars)`,
+    maxlength: 'Use country abbreviation! (max 3 chars)'
+  };
+
   constructor(private builder: FormBuilder) {}
 
   ngOnInit() {
@@ -25,7 +30,7 @@ export class AppComponent {
       address: this.builder.group(
         {
           city: ['', Validators.required],
-          country: ['', Validators.required]
+          country: ['', [Validators.minLength(2), Validators.maxLength(3)]]
         },
         { validator: addressValidator }
       )
@@ -33,6 +38,6 @@ export class AppComponent {
   }
 }
 
-function addressValidator(formGroup: FormGroup) {
-  return { invalidAddress: true };
+function addressValidator(addr: FormGroup) {
+  return addr.value && addr.value.country && addr.value.city ? null : { invalidAddress: true };
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Current implementation don't allows to handle new errors specified in the controlErrors input if the error name is NOT present in the globalErrors config  

And default blurPredicate don't handle focusout on SELECT, it just handle INPUT elements

## What is the new behavior?

- Correctly handle new errors even if not present in the globalConfig
- The default blurPredicate handle even SELECT elements and not only INPUT
- NEW FEATURE: Uniform the possibility to pass in the customErrors and in the global Config an  `HashMap<string | (err: any) => string>` so you can handle errors with a "simple" const string message, or with a function that receive the error and return an errorMessage string based on the err parameter if needed 😉 

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
I believe NO because all the new feature introduced in the new blurPredicate and errors HashMap cover the old cases without change, it simple add new behaviour! 🤔 

## Other information
