### PR TITLE
refactor: 💡 better types for ErrorsMap and Provider

### DIFF
--- a/projects/ngneat/error-tailor/src/lib/control-error.component.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, TemplateRef } from '@angular/core';
-import { HashMap } from './types';
+import { ValidationErrors } from '@angular/forms';
 
 @Component({
   selector: 'control-error',
@@ -22,11 +22,11 @@ import { HashMap } from './types';
 })
 export class ControlErrorComponent {
   _text: string | null = null;
-  _tpl: TemplateRef<{ $implicit: HashMap; text: string }> | undefined;
-  context: { $implicit: HashMap; text: string };
+  _tpl: TemplateRef<{ $implicit: ValidationErrors; text: string }> | undefined;
+  context: { $implicit: ValidationErrors; text: string };
   hide = true;
 
-  createTemplate(tpl: TemplateRef<any>, error, text: string) {
+  createTemplate(tpl: TemplateRef<any>, error: ValidationErrors, text: string) {
     this._tpl = tpl;
     this.context = { $implicit: error, text };
     this.cdr.markForCheck();

--- a/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
@@ -12,20 +12,20 @@ import {
   TemplateRef,
   ViewContainerRef
 } from '@angular/core';
-import { AbstractControl, ControlContainer, NgControl } from '@angular/forms';
+import { AbstractControl, ControlContainer, NgControl, ValidationErrors } from '@angular/forms';
 import { ControlErrorComponent } from './control-error.component';
 import { ControlErrorAnchorDirective } from './control-error-anchor.directive';
 import { EMPTY, fromEvent, merge, Observable, Subject } from 'rxjs';
 import { ErrorTailorConfig, ErrorTailorConfigProvider, FORM_ERRORS } from './providers';
 import { startWith, switchMap, takeUntil } from 'rxjs/operators';
 import { FormSubmitDirective } from './form-submit.directive';
-import { HashMap } from './types';
+import { ErrorsMap } from './types';
 
 @Directive({
   selector: '[formControlName], [formControl], [formGroup], [formGroupName], [formArrayName], [ngModel]'
 })
 export class ControlErrorsDirective implements OnInit, OnDestroy {
-  @Input('controlErrors') customErrors: HashMap = {};
+  @Input('controlErrors') customErrors: ErrorsMap = {};
   @Input() controlErrorsClass: string | undefined;
   @Input() controlErrorsTpl: TemplateRef<any> | undefined;
   @Input() controlErrorsOnBlur = true;
@@ -75,7 +75,7 @@ export class ControlErrorsDirective implements OnInit, OnDestroy {
       .subscribe(() => this.valueChanges());
   }
 
-  private setError(text: string, error?: HashMap) {
+  private setError(text: string, error?: ValidationErrors) {
     if (!this.ref) {
       const factory = this.resolver.resolveComponentFactory(ControlErrorComponent);
       this.ref = this.anchor.createComponent(factory);

--- a/projects/ngneat/error-tailor/src/lib/providers.ts
+++ b/projects/ngneat/error-tailor/src/lib/providers.ts
@@ -1,4 +1,5 @@
-import { InjectionToken, Provider } from '@angular/core';
+import { InjectionToken, ValueSansProvider, FactorySansProvider } from '@angular/core';
+import { ErrorsMap } from './types';
 
 export const FORM_ERRORS = new InjectionToken('FORM_ERRORS', {
   providedIn: 'root',
@@ -7,8 +8,18 @@ export const FORM_ERRORS = new InjectionToken('FORM_ERRORS', {
   }
 });
 
+export interface ErrorsUseValue extends ValueSansProvider {
+  useValue: ErrorsMap;
+}
+
+export interface ErrorsUseFactory extends FactorySansProvider {
+  useFactory: (...args: any[]) => ErrorsMap;
+}
+
+export type ErrorsProvider = ErrorsUseValue | ErrorsUseFactory;
+
 export type ErrorTailorConfig = {
-  errors?: Partial<Provider>;
+  errors?: ErrorsProvider;
   blurPredicate?: (element: Element) => boolean;
 };
 

--- a/projects/ngneat/error-tailor/src/lib/types.ts
+++ b/projects/ngneat/error-tailor/src/lib/types.ts
@@ -1,3 +1,5 @@
 export type HashMap<T = any> = {
-  [err: string]: any;
+  [err: string]: T;
 };
+export type ErrMsgFn = (err: any) => string;
+export type ErrorsMap = HashMap<string | ErrMsgFn>;

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -17,7 +17,7 @@ import { ErrorTailorModule } from '@ngneat/error-tailor';
       errors: {
         useFactory() {
           return {
-            required: error => `This field is required`,
+            required: 'This field is required',
             minlength: ({ requiredLength, actualLength }) => `Expect ${requiredLength} but got ${actualLength}`,
             invalidAddress: error => `Address not valid`
           };


### PR DESCRIPTION
Fully specify TS types for config errors Providers for useValue and
useFactory specific use-cases, both must return ErrorsMap that is a
`HasMap<string | (err)=>string>`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?


```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The actual type for config error: `Partial<Provider>` don't clarify the shape of what must be provide
 
Issue Number: N/A

## What is the new behavior?

Fully TS type check when specify config errors property

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
