### PR TITLE
Feature/reset - Add ability to reset form errors

### DIFF
--- a/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
@@ -89,11 +89,8 @@ export class ControlErrorsDirective implements OnInit, OnDestroy {
       switchMap(submit => (submit ? controlChanges$.pipe(startWith(true)) : NEVER))
     );
 
-    // on reset, clear ViewContainerRef and ComponentRef
-    this.reset$.pipe(takeUntil(this.destroy)).subscribe(() => {
-      this.anchor.clear();
-      this.ref = null;
-    });
+    // on reset, clear ComponentRef and customAnchorDestroyFn
+    this.reset$.pipe(takeUntil(this.destroy)).subscribe(() => this.clearRefs());
 
     merge(changesOnAsync$, changesOnBlur$, changesOnSubmit$)
       .pipe(takeUntil(this.destroy))
@@ -129,11 +126,17 @@ export class ControlErrorsDirective implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.destroy.next();
+    this.clearRefs();
+  }
+
+  private clearRefs(): void {
     if (this.customAnchorDestroyFn) {
       this.customAnchorDestroyFn();
       this.customAnchorDestroyFn = null;
     }
-    if (this.ref) this.ref.destroy();
+    if (this.ref) {
+      this.ref.destroy();
+    }
     this.ref = null;
   }
 

--- a/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
@@ -19,7 +19,7 @@ import { ControlErrorAnchorDirective } from './control-error-anchor.directive';
 import { EMPTY, fromEvent, merge, NEVER, Observable, Subject } from 'rxjs';
 import { ErrorTailorConfig, ErrorTailorConfigProvider, FORM_ERRORS } from './providers';
 import { distinctUntilChanged, mapTo, startWith, switchMap, takeUntil, tap } from 'rxjs/operators';
-import { FormSubmitDirective } from './form-submit.directive';
+import { FormActionDirective } from './form-action.directive';
 import { ErrorsMap } from './types';
 
 @Directive({
@@ -50,7 +50,7 @@ export class ControlErrorsDirective implements OnInit, OnDestroy {
     @Inject(ErrorTailorConfigProvider) private config: ErrorTailorConfig,
     @Inject(FORM_ERRORS) private globalErrors,
     @Optional() private controlErrorAnchorParent: ControlErrorAnchorDirective,
-    @Optional() private form: FormSubmitDirective,
+    @Optional() private form: FormActionDirective,
     @Optional() @Self() private ngControl: NgControl,
     @Optional() @Self() private controlContainer: ControlContainer
   ) {

--- a/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
@@ -82,11 +82,11 @@ export class ControlErrorsDirective implements OnInit, OnDestroy {
       changesOnBlur$ = blur$.pipe(switchMap(() => valueChanges$.pipe(startWith(true))));
     }
 
-    const submitted$ = merge(this.submit$.pipe(mapTo(true)), this.reset$.pipe(mapTo(false)));
+    const submit$ = merge(this.submit$.pipe(mapTo(true)), this.reset$.pipe(mapTo(false)));
 
     // when submitted, submitFirstThenUponChanges
-    const changesOnSubmit$ = submitted$.pipe(
-      switchMap(submitted => (submitted ? controlChanges$.pipe(startWith(true)) : NEVER))
+    const changesOnSubmit$ = submit$.pipe(
+      switchMap(submit => (submit ? controlChanges$.pipe(startWith(true)) : NEVER))
     );
 
     // on reset, clear ViewContainerRef and ComponentRef

--- a/projects/ngneat/error-tailor/src/lib/error-tailor.module.ts
+++ b/projects/ngneat/error-tailor/src/lib/error-tailor.module.ts
@@ -3,17 +3,17 @@ import { ControlErrorsDirective } from './control-error.directive';
 import { ControlErrorAnchorDirective } from './control-error-anchor.directive';
 import { DefaultControlErrorComponent } from './control-error.component';
 import { CommonModule } from '@angular/common';
-import { FormSubmitDirective } from './form-submit.directive';
+import { FormActionDirective } from './form-action.directive';
 import { ErrorTailorConfig, ErrorTailorConfigProvider, FORM_ERRORS } from './providers';
 
-const api = [DefaultControlErrorComponent, ControlErrorAnchorDirective, ControlErrorsDirective, FormSubmitDirective];
+const api = [DefaultControlErrorComponent, ControlErrorAnchorDirective, ControlErrorsDirective, FormActionDirective];
 
 @NgModule({
   declarations: [
     ControlErrorsDirective,
     ControlErrorAnchorDirective,
     DefaultControlErrorComponent,
-    FormSubmitDirective
+    FormActionDirective
   ],
   imports: [CommonModule],
   exports: [api],

--- a/projects/ngneat/error-tailor/src/lib/form-action.directive.spec.ts
+++ b/projects/ngneat/error-tailor/src/lib/form-action.directive.spec.ts
@@ -35,4 +35,23 @@ describe('FormActionDirective', () => {
     expect(submitted).toBeTrue();
     expect(form.classList.contains('form-submitted')).toBeTrue();
   });
+
+  it('should emit reset when form is reset and remove class `form-submitted` after submit', () => {
+    let reset = false;
+
+    spectator.directive.reset$.subscribe({
+      next: () => (reset = true)
+    });
+
+    const form = spectator.query<HTMLButtonElement>('form');
+
+    spectator.dispatchFakeEvent(form, 'submit');
+
+    spectator.detectChanges();
+
+    spectator.dispatchFakeEvent(form, 'reset');
+
+    expect(reset).toBeTrue();
+    expect(form.classList.contains('form-submitted')).toBeFalse();
+  });
 });

--- a/projects/ngneat/error-tailor/src/lib/form-action.directive.spec.ts
+++ b/projects/ngneat/error-tailor/src/lib/form-action.directive.spec.ts
@@ -1,10 +1,10 @@
 import { SpectatorDirective, createDirectiveFactory } from '@ngneat/spectator';
 
-import { FormSubmitDirective } from './form-submit.directive';
+import { FormActionDirective } from './form-action.directive';
 
-describe('FormSubmitDirective', () => {
-  let spectator: SpectatorDirective<FormSubmitDirective>;
-  const createDirective = createDirectiveFactory(FormSubmitDirective);
+describe('FormActionDirective', () => {
+  let spectator: SpectatorDirective<FormActionDirective>;
+  const createDirective = createDirectiveFactory(FormActionDirective);
 
   beforeEach(() => {
     spectator = createDirective(`

--- a/projects/ngneat/error-tailor/src/lib/form-action.directive.ts
+++ b/projects/ngneat/error-tailor/src/lib/form-action.directive.ts
@@ -5,7 +5,7 @@ import { shareReplay, tap } from 'rxjs/operators';
 @Directive({
   selector: 'form[errorTailor]'
 })
-export class FormSubmitDirective {
+export class FormActionDirective {
   submit$: Observable<Event> = fromEvent(this.element, 'submit').pipe(
     tap(() => {
       if (this.element.classList.contains('form-submitted') === false) {

--- a/projects/ngneat/error-tailor/src/lib/form-submit.directive.ts
+++ b/projects/ngneat/error-tailor/src/lib/form-submit.directive.ts
@@ -15,6 +15,13 @@ export class FormSubmitDirective {
     shareReplay({ refCount: true, bufferSize: 1 })
   );
 
+  reset$: Observable<Event> = fromEvent(this.element, 'reset').pipe(
+    tap(() => {
+      this.element.classList.remove('form-submitted');
+    }),
+    shareReplay({ refCount: true, bufferSize: 1 })
+  );
+
   constructor(private host: ElementRef<HTMLFormElement>) {}
 
   get element() {

--- a/projects/ngneat/error-tailor/src/public-api.ts
+++ b/projects/ngneat/error-tailor/src/public-api.ts
@@ -6,5 +6,5 @@ export * from './lib/error-tailor.module';
 export * from './lib/control-error.component';
 export * from './lib/control-error-anchor.directive';
 export * from './lib/control-error.directive';
-export * from './lib/form-submit.directive';
+export * from './lib/form-action.directive';
 export * from './lib/providers';

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -74,3 +74,20 @@
   </div>
   <button class="btn btn-success">Submit</button>
 </form>
+
+<h1>Show Errors On Submit (with Reset)</h1>
+
+<form errorTailor>
+  <div class="form-group">
+    <input
+      class="form-control"
+      ngModel
+      required
+      name="name"
+      [controlErrorsOnBlur]="false"
+      [controlErrorsOnAsync]="false"
+    />
+  </div>
+  <button class="btn btn-success" type="submit">Submit</button>
+  <button class="btn btn-default" type="reset">Reset</button>
+</form>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -11,3 +11,7 @@
   padding: 5px 5px 2px 5px;
   margin-bottom: 0px;
 }
+
+h1 {
+  margin-top: 1em;
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Feature
[x] Code style update (formatting, local variables)
```

## What is the current behavior?

Currently when form is reset after submission errors display will persist

## What is the new behavior?

Triggering a reset event will clear visible errors and truly reset the form.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

Not sure if I should amend the docs to point out this functionality. I think it should just be expected that a reset event will actually reset the form though right? Happy to add if you think it's relevant to point out.
