### PR TITLE
feat: add support for async errorText

### DIFF
--- a/projects/ngneat/error-tailor/src/lib/control-error.component.spec.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.component.spec.ts
@@ -1,6 +1,7 @@
 import { Spectator, createComponentFactory, byText } from '@ngneat/spectator';
 
 import { DefaultControlErrorComponent } from './control-error.component';
+import { of } from 'rxjs';
 
 describe('ControlErrorComponent', () => {
   let spectator: Spectator<DefaultControlErrorComponent>;
@@ -14,31 +15,29 @@ describe('ControlErrorComponent', () => {
 
   describe('when text is setted', () => {
     it('should show text error when it is setted', () => {
-      spectator.component.text = 'test';
+      spectator.component.text$ = of('test');
 
       spectator.detectChanges();
 
-      expect(spectator.component.errorText).toBe('test');
       expect(spectator.component.hideError).toBeFalse();
       expect(spectator.query(byText('test'))).toBeTruthy();
     });
 
     it('should hide text when error is empty', () => {
-      spectator.component.text = 'test';
+      spectator.component.text$ = of('test');
 
       spectator.detectChanges();
 
-      spectator.component.text = '';
+      spectator.component.text$ = of('');
 
       spectator.detectChanges();
 
-      expect(spectator.component.errorText).toBe('');
       expect(spectator.component.hideError).toBeTrue();
       expect(spectator.query(byText('test'))).toBeNull();
     });
 
     it('should do nothing when text has not changed', () => {
-      spectator.component.text = 'test';
+      spectator.component.text$ = of('test');
 
       let setHasNotBeenCalled = true;
 
@@ -51,7 +50,7 @@ describe('ControlErrorComponent', () => {
         }
       });
 
-      spectator.component.text = 'test';
+      spectator.component.text$ = of('test');
 
       expect(setHasNotBeenCalled).toBeTrue();
     });
@@ -63,14 +62,12 @@ describe('ControlErrorComponent', () => {
     expect(spectator.element).toHaveClass('customClassTest');
   });
 
-  it('should create passed template and send its context', () => {
+  it('should create passed template and send its context', async () => {
     const { component } = spectator;
-    component.createTemplate('fakeTemplate' as any, { testError: 'test' }, 'test error');
+    component.createTemplate('fakeTemplate' as any, { testError: 'test' }, of('test error'));
 
-    expect(component.errorContext).toEqual({
-      $implicit: { testError: 'test' },
-      text: 'test error'
-    });
+    expect(component.errorContext.$implicit).toEqual({ testError: 'test' });
+    await expectAsync(component.errorContext.text$.toPromise()).toBeResolvedTo('test error');
 
     expect(component.errorTemplate).toBe('fakeTemplate' as any);
   });

--- a/projects/ngneat/error-tailor/src/lib/control-error.component.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.component.ts
@@ -1,18 +1,22 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, TemplateRef } from '@angular/core';
 import { ValidationErrors } from '@angular/forms';
+import { Observable, of } from 'rxjs';
+import { tap } from 'rxjs/operators';
 
 export type ErrorComponentTemplate = TemplateRef<{ $implicit: ValidationErrors; text: string }>;
 
 export interface ControlErrorComponent {
   customClass: string;
-  text: string | null;
-  createTemplate?(tpl: ErrorComponentTemplate, error: ValidationErrors, text: string): void;
+  text$: Observable<string> | null;
+  createTemplate?(tpl: ErrorComponentTemplate, error: ValidationErrors, text$: Observable<string>): void;
 }
 
 @Component({
   selector: 'control-error',
   template: `
-    <label class="control-error" [class.hide-control]="hideError" *ngIf="!errorTemplate">{{ errorText }}</label>
+    <label class="control-error" [class.hide-control]="hideError" *ngIf="!errorTemplate">{{
+      errorText$ | async
+    }}</label>
     <ng-template *ngTemplateOutlet="errorTemplate; context: errorContext"></ng-template>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -29,14 +33,14 @@ export interface ControlErrorComponent {
   ]
 })
 export class DefaultControlErrorComponent implements ControlErrorComponent {
-  errorText: string | null = null;
+  errorText$: Observable<string> | null = null;
   errorTemplate: ErrorComponentTemplate | undefined;
-  errorContext: { $implicit: ValidationErrors; text: string };
+  errorContext: { $implicit: ValidationErrors; text$: Observable<string> };
   hideError = true;
 
-  createTemplate(tpl: ErrorComponentTemplate, error: ValidationErrors, text: string) {
+  createTemplate(tpl: ErrorComponentTemplate, error: ValidationErrors, text$: Observable<string>) {
     this.errorTemplate = tpl;
-    this.errorContext = { $implicit: error, text };
+    this.errorContext = { $implicit: error, text$ };
     this.cdr.markForCheck();
   }
 
@@ -44,12 +48,14 @@ export class DefaultControlErrorComponent implements ControlErrorComponent {
     this.host.nativeElement.classList.add(className);
   }
 
-  set text(value: string | null) {
-    if (value !== this.errorText) {
-      this.errorText = value;
-      this.hideError = !value;
-      this.cdr.markForCheck();
-    }
+  set text$(value: Observable<string> | null) {
+    this.errorText$ = (value || of(null)).pipe(
+      tap(val => {
+        this.hideError = !val;
+        this.cdr.detectChanges();
+      })
+    );
+    this.cdr.markForCheck();
   }
 
   constructor(private cdr: ChangeDetectorRef, private host: ElementRef<HTMLElement>) {}

--- a/projects/ngneat/error-tailor/src/lib/control-error.directive.spec.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.directive.spec.ts
@@ -327,8 +327,8 @@ describe('ControlErrorDirective', () => {
         <form [formGroup]="form" errorTailor>
           <input formControlName="customErrors" placeholder="Custom errors" [controlErrors]="customErrors" />
 
-          <ng-template #customTpl let-errors let-text="text">
-            custom template {{ errors | json }} {{ text }}
+          <ng-template #customTpl let-errors let-text$="text$">
+            custom template {{ errors | json }} {{ text$ | async }}
           </ng-template>
           <input formControlName="customTemplate" placeholder="Custom template" [controlErrorsTpl]="customTpl" />
 
@@ -444,7 +444,7 @@ describe('ControlErrorDirective', () => {
     @Component({
       selector: 'custom-error-component',
       template: `
-        <h1>{{ errorText }}</h1>
+        <h1>{{ errorText$ | async }}</h1>
       `
     })
     class CustomControlErrorComponent extends DefaultControlErrorComponent {}

--- a/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
@@ -16,7 +16,7 @@ import {
 import { AbstractControl, ControlContainer, NgControl, ValidationErrors } from '@angular/forms';
 import { DefaultControlErrorComponent, ControlErrorComponent } from './control-error.component';
 import { ControlErrorAnchorDirective } from './control-error-anchor.directive';
-import { EMPTY, fromEvent, merge, NEVER, Observable, Subject } from 'rxjs';
+import { EMPTY, fromEvent, isObservable, merge, NEVER, Observable, of, Subject } from 'rxjs';
 import { ErrorTailorConfig, ErrorTailorConfigProvider, FORM_ERRORS } from './providers';
 import { distinctUntilChanged, mapTo, startWith, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { FormActionDirective } from './form-action.directive';
@@ -98,7 +98,7 @@ export class ControlErrorsDirective implements OnInit, OnDestroy {
       .subscribe(() => this.valueChanges());
   }
 
-  private setError(text: string, error?: ValidationErrors) {
+  private setError(text: string | Observable<string>, error?: ValidationErrors) {
     if (!this.ref) {
       const factory = this.resolver.resolveComponentFactory<ControlErrorComponent>(
         this.mergedConfig.controlErrorComponent
@@ -106,11 +106,12 @@ export class ControlErrorsDirective implements OnInit, OnDestroy {
       this.ref = this.anchor.createComponent<ControlErrorComponent>(factory);
     }
     const instance = this.ref.instance;
+    const text$ = isObservable(text) ? text : of(text);
 
     if (this.controlErrorsTpl) {
-      instance.createTemplate(this.controlErrorsTpl, error, text);
+      instance.createTemplate(this.controlErrorsTpl, error, text$);
     } else {
-      instance.text = text;
+      instance.text$ = text$;
     }
 
     if (this.controlErrorsClass) {

--- a/projects/ngneat/error-tailor/src/lib/types.ts
+++ b/projects/ngneat/error-tailor/src/lib/types.ts
@@ -1,5 +1,7 @@
+import { Observable } from 'rxjs';
+
 export type HashMap<T = any> = {
   [err: string]: T;
 };
-export type ErrMsgFn = (err: any) => string;
+export type ErrMsgFn = (err: any) => string | Observable<string>;
 export type ErrorsMap = HashMap<string | ErrMsgFn>;

--- a/src/app/custom-error-control/custom-error-control.component.ts
+++ b/src/app/custom-error-control/custom-error-control.component.ts
@@ -5,7 +5,7 @@ import { DefaultControlErrorComponent } from '@ngneat/error-tailor';
   selector: 'custom-control-error',
   template: `
     <div class="control-error" [class.hide-control]="hideError" *ngIf="!errorTemplate">
-      <h3>{{ errorText }}</h3>
+      <h3>{{ errorText$ | async }}</h3>
     </div>
     <ng-template *ngTemplateOutlet="errorTemplate; context: errorContext"></ng-template>
   `,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 47

## What is the new behavior?
It is possible to return Observable<string> instead of string when defining errors.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Interface ControlErrorComponent has now field text$: Observable<string> instead of text: string.

## Other information
