### PR TITLE
feat: multiply css classes for control error component

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ The directive will show all errors for a form field automatically in two instanc
 
 ## Inputs
 
-- `controlErrorsClass` - A custom class that'll be added to the control error component, a component that is added after the form field when an error needs to be displayed:
+- `controlErrorsClass` - A custom classes that'll be added to the control error component, a component that is added after the form field when an error needs to be displayed:
 
 ```html
 <input class="form-control" formControlName="city" 
-       placeholder="City" controlErrorsClass="my-class" />
+       placeholder="City" controlErrorsClass="my-class other-class" />
 ```
 
 - `controlErrorsTpl` - A custom error template to be used instead of the control error component's default view: 

--- a/projects/ngneat/error-tailor/src/lib/control-error.component.spec.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.component.spec.ts
@@ -63,6 +63,18 @@ describe('ControlErrorComponent', () => {
     expect(spectator.element).toHaveClass('customClassTest');
   });
 
+  it('should set multiply css classes on host element', () => {
+    spectator.component.customClass = 'customClassTest1 customClassTest2';
+
+    expect(spectator.element).toHaveClass(['customClassTest1', 'customClassTest2']);
+  });
+
+  it('should set multiply css classes as array on host element', () => {
+    spectator.component.customClass = ['customClassTest1', 'customClassTest2'];
+
+    expect(spectator.element).toHaveClass(['customClassTest1', 'customClassTest2']);
+  });
+
   it('should create passed template and send its context', () => {
     const { component } = spectator;
     component.createTemplate('fakeTemplate' as any, { testError: 'test' }, 'test error');

--- a/projects/ngneat/error-tailor/src/lib/control-error.component.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.component.ts
@@ -4,7 +4,7 @@ import { ValidationErrors } from '@angular/forms';
 export type ErrorComponentTemplate = TemplateRef<{ $implicit: ValidationErrors; text: string }>;
 
 export interface ControlErrorComponent {
-  customClass: string;
+  customClass: string | string[];
   text: string | null;
   createTemplate?(tpl: ErrorComponentTemplate, error: ValidationErrors, text: string): void;
 }
@@ -40,8 +40,9 @@ export class DefaultControlErrorComponent implements ControlErrorComponent {
     this.cdr.markForCheck();
   }
 
-  set customClass(className: string) {
-    this.host.nativeElement.classList.add(className);
+  set customClass(classes: string | string[]) {
+    const classesToAdd = Array.isArray(classes) ? classes : classes.split(/\s/);
+    this.host.nativeElement.classList.add(...classesToAdd);
   }
 
   set text(value: string | null) {

--- a/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
@@ -29,7 +29,7 @@ import { ErrorsMap } from './types';
 })
 export class ControlErrorsDirective implements OnInit, OnDestroy {
   @Input('controlErrors') customErrors: ErrorsMap = {};
-  @Input() controlErrorsClass: string | undefined;
+  @Input() controlErrorsClass: string | string[] | undefined;
   @Input() controlErrorsTpl: TemplateRef<any> | undefined;
   @Input() controlErrorsOnAsync = true;
   @Input() controlErrorsOnBlur = true;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently, we can use only one class for the `control-error` component.

Issue Number: #31 

## What is the new behavior?

The directive allow for multiple classes as string and array.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
close #31 