### PR TITLE
fix: async validator work

### DIFF
--- a/projects/ngneat/error-tailor/src/lib/control-error.directive.spec.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.directive.spec.ts
@@ -79,7 +79,7 @@ describe('ControlErrorDirective', () => {
         ignored: ['', Validators.required],
         explicit: [''],
         names: this.builder.array([this.createName(), this.createName()], this.validator),
-        username: ['', null, this.usernameValidator.bind(this)],
+        username: ['', Validators.required, this.usernameValidator.bind(this)],
         onSubmitOnly: ['', [Validators.required]],
         onEveryChange: ['', [Validators.required]]
       });
@@ -123,6 +123,8 @@ describe('ControlErrorDirective', () => {
 
     it('should show errors on interactions', () => {
       const nameInput = spectator.query<HTMLInputElement>(byPlaceholder('Name'));
+      const usernameInput = spectator.query<HTMLInputElement>(byPlaceholder('Username'));
+      typeInElementAndFocusOut(spectator, 'async', usernameInput);
 
       typeInElementAndFocusOut(spectator, 't', nameInput);
 

--- a/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
@@ -91,7 +91,7 @@ export class ControlErrorsDirective implements OnInit, OnDestroy {
 
     if (this.mergedConfig.controlErrorsOn.async && hasAsyncValidator) {
       // hasAsyncThenUponStatusChange
-      changesOnAsync$ = statusChanges$.pipe();
+      changesOnAsync$ = statusChanges$;
     }
 
     if (this.isInput && this.mergedConfig.controlErrorsOn.change) {

--- a/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
@@ -91,7 +91,7 @@ export class ControlErrorsDirective implements OnInit, OnDestroy {
 
     if (this.mergedConfig.controlErrorsOn.async && hasAsyncValidator) {
       // hasAsyncThenUponStatusChange
-      changesOnAsync$ = statusChanges$.pipe(startWith(true));
+      changesOnAsync$ = statusChanges$.pipe();
     }
 
     if (this.isInput && this.mergedConfig.controlErrorsOn.change) {


### PR DESCRIPTION
Fix async validator work in conjunction with Validators.required

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

If we are add for one control Required and any async validator, control will be have Required error on start

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 41

## What is the new behavior?

Async and Required validator work correctly

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
