### PR TITLE
feat: support showing errors when a control is marked as touched

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ export class AppComponent {
 }
 ```
 
-The directive will show all errors for a form field automatically in two instances - on the field element blur and on form submit.
-
 ### Customize the behavior
+
+By default the directive will show all errors for a form field automatically in two instances: on the field element blur and on form submit.
 
 The default behavior can be overridden globally or on a per control basis.
 
@@ -125,8 +125,8 @@ bootstrapApplication(AppComponent, {
         }
       },
       controlErrorsOn: {
-        change: true, // errors will be shown/hidden on every change
-        touched: true, // errors will be shown/hidden when the controls are marked as touched
+        change: true, // errors are shown/hidden on every change
+        touched: true, // errors are shown/hidden when the controls are marked as touched
       }
     })
   ]

--- a/README.md
+++ b/README.md
@@ -216,6 +216,12 @@ One typical case when to use it is radio buttons in the same radio group where i
 <input [controlErrorsOnChange]="true" formControlName="name" />
 ```
 
+- `controlErrorsOnTouched` - To modify the error display behavior to show errors when the control is marked as `touched` via `control.markAsTouched()` or `form.markAllAsTouched()`:
+
+```html
+<input [controlErrorsOnTouched]="true" formControlName="name" />
+```
+
 ## Methods
 
 - `showError()` - Programmatic access to show a control error component (without a blur or a submit event). A validation error should still exist on that element. The key is the published `exportAs` reference of `errorTailor` to a directive instance of `ControlErrorsDirective` and calling its public method `showError()`.
@@ -336,17 +342,29 @@ bootstrapApplication(AppComponent, {
 
   ```
 
-- `controlErrorsOn` - Optional. An object that allows the default behavior for showing the errors to be overridden. (each individual property in the object is optional, so it's possible to override only 1 setting)
+- `controlErrorsOn` - Optional. Allows to override the default behavior for showing the errors. These are the possible properties and their defaults:
 
-```ts
-{
-  controlErrorsOn: {
-    async: true,  // (default: true)
-    blur: true,   // (default: true)
-    change: true, // (default: false)
+  ```ts
+  {
+    controlErrorsOn: {
+      async: true,
+      blur: true,
+      change: false,
+      touched: false,
+    }
   }
-}
-```
+  ```
+
+  The object will be merged with the default configuration object, so you can simply define one or more properties that you wish to override:
+
+  ```ts
+  {
+    controlErrorsOn: {
+      change: true,
+      touched: true,
+    }
+  }
+  ```
 
 ## Recipes
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,36 @@ export class AppComponent {
 
 The directive will show all errors for a form field automatically in two instances - on the field element blur and on form submit.
 
+### Customize the behavior
+
+The default behavior can be overridden globally or on a per control basis.
+
+If you want to override the behavior globally, so that it affects all form controls, you can do so via the `controlErrorsOn` property:
+
+```ts
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideErrorTailorConfig({
+      errors: {
+        useValue: {
+          required: 'This field is required'
+        }
+      },
+      controlErrorsOn: {
+        change: true, // errors will be shown/hidden on every change
+        touched: true, // errors will be shown/hidden when the controls are marked as touched
+      }
+    })
+  ]
+})
+```
+
+Or you can change the behavior of a single form control by adding the relevant inputs. For example, to only show the errors on submit you can set to `false` both `controlErrorsOnBlur` and `controlErrorsOnAsync`:
+
+```html
+<input [controlErrorsOnBlur]="false" [controlErrorsOnAsync]="false" formControlName="name" />
+```
+
 ## Inputs
 
 - `controlErrorsClass` - A custom classes that'll be added to the control error component and override custom classes from global config, a component that is added after the form field when an error needs to be displayed:

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ One typical case when to use it is radio buttons in the same radio group where i
 <input [controlErrorsOnChange]="true" formControlName="name" />
 ```
 
-- `controlErrorsOnTouched` - To modify the error display behavior to show errors when the control is marked as `touched` via `control.markAsTouched()` or `form.markAllAsTouched()`:
+- `controlErrorsOnTouched` - To modify the error display behavior to show errors when the control is marked as `touched` via `control.markAsTouched()` or `formGroup.markAllAsTouched()`:
 
 ```html
 <input [controlErrorsOnTouched]="true" formControlName="name" />

--- a/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
@@ -260,6 +260,7 @@ export class ControlErrorsDirective implements OnInit, OnDestroy {
         blur: this.controlErrorsOnBlur ?? this.config.controlErrorsOn?.blur ?? true,
         change: this.controlErrorsOnChange ?? this.config.controlErrorsOn?.change ?? false,
         status: this.controlErrorsOnStatusChange ?? this.config.controlErrorsOn?.status ?? false,
+        touched: this.controlErrorsOnTouched ?? this.config.controlErrorsOn?.touched ?? false,
       },
     };
   }

--- a/projects/ngneat/error-tailor/src/lib/error-tailor.providers.ts
+++ b/projects/ngneat/error-tailor/src/lib/error-tailor.providers.ts
@@ -32,6 +32,7 @@ export type ErrorTailorConfig = {
     blur?: boolean;
     change?: boolean;
     status?: boolean;
+    touched?: boolean;
   };
 };
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="form" errorTailor>
   <div class="form-group">
-    <input class="form-control" formControlName="name" placeholder="Name" />
+    <input class="form-control" formControlName="name" placeholder="Name" [controlErrorsOnTouched]="true" />
   </div>
   <div class="form-check form-group">
     <input class="form-check-input" type="checkbox" formControlName="terms" id="check" [controlErrorAnchor]="anchor" />
@@ -67,6 +67,16 @@
       Showing/hiding errors on cookies validation:
       <button type="button" class="btn btn-success btn-custom" (click)="showError()">Show error</button>
       <button type="button" class="btn btn-success btn-custom" (click)="hideError()">Hide error</button>
+    </span>
+  </div>
+  <br />
+  <div class="text-right">
+    <span>
+      Showing/hiding errors on name via touched:
+      <button type="button" class="btn btn-success btn-custom" (click)="markNameAsTouched()">Mark as touched</button>
+      <button type="button" class="btn btn-success btn-custom" (click)="markNameAsUntouched()">
+        Mark as untouched
+      </button>
     </span>
   </div>
   <br />

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,7 +6,7 @@ import { ControlErrorsDirective } from '@ngneat/error-tailor';
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss']
+  styleUrls: ['./app.component.scss'],
 })
 export class AppComponent {
   form: UntypedFormGroup;
@@ -14,19 +14,19 @@ export class AppComponent {
 
   options = Array.from(Array(5), (_, i) => ({
     label: `Animal ${i + 1}`,
-    id: i + 1
+    id: i + 1,
   }));
 
   extraErrors = {
     minlength: ({ requiredLength }) => `Use country abbreviation! (min ${requiredLength} chars)`,
-    maxlength: 'Use country abbreviation! (max 3 chars)'
+    maxlength: 'Use country abbreviation! (max 3 chars)',
   };
 
   @ViewChild('gdprErrorTailor', { static: true }) gdprErrorTailor: ControlErrorsDirective;
 
   formGroup = this.builder.group({
     name: [null, Validators.required],
-    emailAddresses: this.builder.array([this.initEmailAddressFields()])
+    emailAddresses: this.builder.array([this.initEmailAddressFields()]),
   });
 
   get emailAddresses() {
@@ -36,7 +36,7 @@ export class AppComponent {
   initEmailAddressFields(): UntypedFormGroup {
     return this.builder.group({
       label: [null, Validators.required],
-      emailAddress: [null, [Validators.required, Validators.email]]
+      emailAddress: [null, [Validators.required, Validators.email]],
     });
   }
 
@@ -62,11 +62,11 @@ export class AppComponent {
       address: this.builder.group(
         {
           city: ['', Validators.required],
-          country: ['', [Validators.minLength(2), Validators.maxLength(3)]]
+          country: ['', [Validators.minLength(2), Validators.maxLength(3)]],
         },
-        { validator: addressValidator }
+        { validator: addressValidator },
       ),
-      gdpr: [false, Validators.requiredTrue]
+      gdpr: [false, Validators.requiredTrue],
     });
     /**
      * It's not necessary to set errors directly. It's done via the validator itself.
@@ -82,6 +82,14 @@ export class AppComponent {
 
   hideError(): void {
     this.gdprErrorTailor.hideError();
+  }
+
+  markNameAsTouched(): void {
+    this.form.controls.name.markAsTouched();
+  }
+
+  markNameAsUntouched(): void {
+    this.form.controls.name.markAsUntouched();
   }
 
   submit() {}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ngneat/error-tailor/issues/64

Currently errors are not shown if a control is marked as `touched` programmatically via `control.markAsTouched()` or `formGroup.markAllAsTouched()`.

## What is the new behavior?

When setting `controlErrorsOn: { touched: true }` in the config or when setting the `[controlErrorsOnTouched]="true"` input on a form control, errors will be show when the control is marked as touched (`control.touched === true`) and will be hidden if the control becomes pristine again after being `touched`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->