### PR TITLE
feat: enable global errors to access directive Injector

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ bootstrapApplication(AppComponent, {
 <!-- prettier-ignore-end -->
 
 The `errors` config property takes a partial `Provider`, that should provide a `HashMap<string | (err:any) => string>` that is an object with keys corresponding to the errors name that you want to handle, and values that can be a simple string, or function that return a string used as error message to be shown.
+This function runs inside the directive injector context.
+
 Now the only thing you need to add is the `errorTailor` directive to your form:
 
 ```html

--- a/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
+++ b/projects/ngneat/error-tailor/src/lib/control-error.directive.ts
@@ -4,11 +4,13 @@ import {
   ElementRef,
   EmbeddedViewRef,
   Inject,
+  Injector,
   Input,
   isDevMode,
   OnDestroy,
   OnInit,
   Optional,
+  runInInjectionContext,
   Self,
   TemplateRef,
   ViewContainerRef,
@@ -72,6 +74,7 @@ export class ControlErrorsDirective implements OnInit, OnDestroy {
     @Optional() private form: FormActionDirective,
     @Optional() @Self() private ngControl: NgControl,
     @Optional() @Self() private controlContainer: ControlContainer,
+    private injector: Injector,
   ) {
     this.host = elementRef.nativeElement as HTMLElement;
     this.submit$ = this.form ? this.form.submit$ : EMPTY;
@@ -193,7 +196,10 @@ export class ControlErrorsDirective implements OnInit, OnDestroy {
         return;
       }
 
-      const text = typeof getError === 'function' ? getError(controlErrors[firstKey]) : getError;
+      const text =
+        typeof getError === 'function'
+          ? runInInjectionContext(this.injector, () => getError(controlErrors[firstKey]))
+          : getError;
       this.addCustomClass();
       this.setError(text, controlErrors);
     }


### PR DESCRIPTION
Allow the Injector from the directive to be available in the global errors configuration.

This enables retrieving custom component error messages from the global errors without needing to specify them at the component level each time.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

At the moment, global errors cannot access component-specific information to compute the error message (i.e. no access to the control form name).

When we need to have component specific information, we need to pass it at the component level through `controlErrors` input.

```
<input class="form-control" formControlName="country" placeholder="Country"
       [controlErrors]="extraErrors" />
```

This can clutter the code for applications that have a majority of component specific messages.
 
Issue Number: https://github.com/ngneat/error-tailor/issues/117

## What is the new behavior?

Global error message computation can now access the error directive injector.

Hence retrieve the form control name or any other component in the template hierarchy.

Sample usage

```
provideErrorTailorConfig({
errors: {
  useValue: {
    required: () => 'required error',
    custom: (err, injector) => {
      const controlName = injector.get(NgControl).name;
      return `custom error for control ${controlName}`;
    },
  },
},
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
